### PR TITLE
Fix import path for bitcask

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/pkg/xattr v0.4.3
 	github.com/postfinance/single v0.0.1
-	github.com/prologic/bitcask v0.3.10
+	git.mills.io/prologic/bitcask v0.3.10
 	github.com/shirou/gopsutil/v3 v3.21.1
 )

--- a/src/db/database.go
+++ b/src/db/database.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"fmt"
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 	"os"
 	"sync"
 	"time"


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇